### PR TITLE
MAINT: reformatting and fixing up some style issues

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -2,11 +2,15 @@
 
 
 ## Document Purpose and Scope
-The purpose of this document is to facilitate science with SPHEREx data by providing users with an overview of the SPHEREx data that are available at the NASA/IPAC Infrared Science Archive (IRSA) at Caltech, as well as instructions for accessing and downloading these data. We also provide tips for exploring the data and getting help with any questions you may have. This User Guide will evolve as the SPHEREx project delivers new data products and tools to IRSA to make available to the public.
+The purpose of this document is to facilitate science with SPHEREx data by providing users with an overview of the SPHEREx data that are available at the NASA/IPAC Infrared Science Archive (IRSA) at Caltech, as well as instructions for accessing and downloading these data.
+We also provide tips for exploring the data and getting help with any questions you may have.
+This User Guide will evolve as the SPHEREx project delivers new data products and tools to IRSA to make available to the public.
 
 ## SPHEREx Overview
 
-SPHEREx is a NASA Astrophysics Medium Explorer mission that launched in March 2025. During its planned two-year mission, SPHEREx will obtain 0.75-5 micron spectroscopy over the entire sky, with deeper data in the SPHEREx Deep Fields. SPHEREx data will be used to:
+SPHEREx is a NASA Astrophysics Medium Explorer mission that launched in March 2025.
+During its planned two-year mission, SPHEREx will obtain 0.75-5 micron spectroscopy over the entire sky, with deeper data in the SPHEREx Deep Fields.
+SPHEREx data will be used to:
 
 * **constrain the physics of inflation** by measuring its imprints on the three-dimensional large-scale distribution of matter,
 * **trace the history of galactic light production** through a deep multi-band measurement of large-scale clustering,

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -27,4 +27,4 @@ More information is available in the "Mission Overview" section of the SPHEREx E
 
 [SPHEREx project website](https://spherex.caltech.edu/)
 
-[SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf)
+[SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf)

--- a/documentation/spherex_data_access.md
+++ b/documentation/spherex_data_access.md
@@ -1,6 +1,8 @@
 # SPHEREx Data Access
 
-IRSA serves SPHEREx data on premises at IPAC. IRSA provides layered access to these data to support a variety of use cases and users. These layers include:
+IRSA serves SPHEREx data on premises at IPAC.
+IRSA provides layered access to these data to support a variety of use cases and users.
+These layers include:
 
 * **Browsable Directories:** SPHEREx on-premises data products are laid out in directories that can be navigated with standard web browsers.
 * **Application Program Interfaces:** IRSA provides SPHEREx data access APIs that are compliant with International Virtual Observatory Alliance (IVOA) standards.
@@ -10,7 +12,8 @@ IRSA serves SPHEREx data on premises at IPAC. IRSA provides layered access to th
 Each of these data access layers is described in greater detail in the subsections below.
 
 ## Browsable Directories
-SPHEREx data products are laid out in directories that can be navigated with standard web browsers. This is convenient for users to get a quick sense of the types of data products that are available, to quickly download some examples by clicking through the directory tree, and to script bulk downloads using wget or curl.
+SPHEREx data products are laid out in directories that can be navigated with standard web browsers.
+This is convenient for users to get a quick sense of the types of data products that are available, to quickly download some examples by clicking through the directory tree, and to script bulk downloads using wget or curl.
 
 The root of the SPHEREx data quick release data directories is:
 https://irsa.ipac.caltech.edu/ibe/data/spherex/qr
@@ -32,15 +35,22 @@ The content of each subdirectory is described in greater detail in the Data Prod
 
 ## Application Program Interfaces (APIs)
 
-IRSA provides API access to SPHEREx Spectral Images through version 2 of the VO Simple Image Access (SIA2) protocol. SIA2 allows users to query for a list of images that satisfy constraints based on position(s) on the sky, band, time, ID, and instrument. The list returned by the service includes data access URLs, which can be used to retrieve some or all of the images in the list using wget or curl. A brief summary of SIA2 for accessing SPHEREx data for IRSA is given below. Additional [documentation on IRSA’s SIA2 service](https://irsa.ipac.caltech.edu/ibe/sia.html) can be found on the IRSA website:
+IRSA provides API access to SPHEREx Spectral Images through version 2 of the VO Simple Image Access (SIA2) protocol.
+SIA2 allows users to query for a list of images that satisfy constraints based on position(s) on the sky, band, time, ID, and instrument.
+The list returned by the service includes data access URLs, which can be used to retrieve some or all of the images in the list using wget or curl.
+A brief summary of SIA2 for accessing SPHEREx data for IRSA is given below.
+Additional [documentation on IRSA’s SIA2 service](https://irsa.ipac.caltech.edu/ibe/sia.html) can be found on the IRSA website:
 
-Note: SPHEREx data are ingested on a weekly basis. Due to the nature of the ingestion process, new SPHEREx data will first be available in the browsable directories and in the SPHEREx Data Explorer GUI. Availability via SIA2 and Python libraries like Astroquery and PyVO will lag on the order of a day.
+Note: SPHEREx data are ingested on a weekly basis.
+Due to the nature of the ingestion process, new SPHEREx data will first be available in the browsable directories and in the SPHEREx Data Explorer GUI.
+Availability via SIA2 and Python libraries like Astroquery and PyVO will lag on the order of a day.
 
 IRSA's generric SIA2 endpoint is:
 
 `https://irsa.ipac.caltech.edu/SIA?`
 
-Users must add a `COLLECTION` parameter to this endpoint to specify which dataset to search.  There are three SPHEREx-related SIA2 collections:
+Users must add a `COLLECTION` parameter to this endpoint to specify which dataset to search.
+ There are three SPHEREx-related SIA2 collections:
 
 * SPHEREx Quick Release Spectral Image MEFs that are part of the SPHEREx **Wide Survey** can be accessed with: `COLLECTION=spherex_qr`
 
@@ -48,7 +58,8 @@ Users must add a `COLLECTION` parameter to this endpoint to specify which datase
 
 * SPHEREx Quick Release **Calibration files** can be accessed with: `COLLECTION=spherex_qr_cal`
 
-You can use `wget` or `curl` to submit SIA2 queries from the command line. For example:
+You can use `wget` or `curl` to submit SIA2 queries from the command line.
+For example:
 
 * `wget -O example1.html "https://irsatest.ipac.caltech.edu/SIA?COLLECTION=spherex_qr&POS=circle+127.69444+-39.17760+0.01&RESPONSEFORMAT=HTML"`
 

--- a/documentation/spherex_data_access.md
+++ b/documentation/spherex_data_access.md
@@ -41,9 +41,11 @@ The list returned by the service includes data access URLs, which can be used to
 A brief summary of SIA2 for accessing SPHEREx data for IRSA is given below.
 Additional [documentation on IRSA’s SIA2 service](https://irsa.ipac.caltech.edu/ibe/sia.html) can be found on the IRSA website:
 
-Note: SPHEREx data are ingested on a weekly basis.
+:::{note}
+SPHEREx data are ingested on a weekly basis.
 Due to the nature of the ingestion process, new SPHEREx data will first be available in the browsable directories and in the SPHEREx Data Explorer GUI.
 Availability via SIA2 and Python libraries like Astroquery and PyVO will lag on the order of a day.
+:::
 
 IRSA's generric SIA2 endpoint is:
 
@@ -69,10 +71,13 @@ See the next section to learn how to use Python wrappers around IRSA’s SIA2 se
 
 If you would like to take advantage of IRSA’s SIA2 service for querying SPHEREx images, but prefer to use Python rather than the command line, you may be interested in using one of two Python libraries:
 
-*	**PyVO**  -- This module lets you find and retrieve astronomical data available from archives that support standard IVOA protocols.
-*	**Astroquery**  -- This module provides access to IRSA's public astrophysics data from projects such as SPHEREx, Euclid, Spitzer, WISE/NEOWISE, SOFIA, IRTF, 2MASS, Herschel, IRAS, and ZTF.
+[PyVO](https://github.com/astropy/pyvo)
+ : This module lets you find and retrieve astronomical data available from archives that support standard IVOA protocols.
 
-Examples of data queries using both of these libraries can be found in [IRSA’s Python Notebook Tutorial Repository](https://caltech-ipac.github.io/irsa-tutorials/):
+[Astroquery](https://github.com/astropy/astroquery)
+ : This module provides access to IRSA's public astrophysics data from projects such as SPHEREx, Euclid, Spitzer, WISE/NEOWISE, SOFIA, IRTF, 2MASS, Herschel, IRAS, and ZTF.
+
+Examples of data queries using both of these libraries can be found in [IRSA’s Python Notebook Tutorial Repository](https://caltech-ipac.github.io/irsa-tutorials/).
 
 ## SPHEREx Data Explorer Web Application
 

--- a/documentation/spherex_data_access.md
+++ b/documentation/spherex_data_access.md
@@ -30,7 +30,7 @@ The public data products are organized into subdirectories based on the followin
 * **Read Noise Parameters:** `readnoise_pars/base-[Processing Date]/[Detector]/`
 * **Spectral WCS:** `spectral_wcs/base-[Processing Date]/[Detector]/`
 
-The content of each subdirectory is described in greater detail in the Data Products section of this user guide and in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+The content of each subdirectory is described in greater detail in the Data Products section of this user guide and in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 
 
 ## Application Program Interfaces (APIs)

--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -1,6 +1,6 @@
 # SPHEREx Data Products Available at IRSA
 
-A detailed description of SPHEREx data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+A detailed description of SPHEREx data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 Here we provide a concise summary of the science, calibration, and additional data products available at IRSA.
 This summary includes filenaming conventions, for which we adopt the following definitions:
 
@@ -40,7 +40,7 @@ IMAGE
 
 FLAG
  : Bitmap of per-pixel status and processing flags, stored as a 2040 x 2040 image.
-   The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+   The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 
 VARIANCE
  : Variance of calibrated surface brightness flux in units of (MJy/sr)^2, stored as a 2,040 x 2,040 image.
@@ -174,7 +174,7 @@ Pixel values are 1 for pixels known to be permanently non-functioning and 0 othe
 
 The Nonlinearity Parameter products are ~79 MB multi-extension FITS files (one per detector).
 Each file contains 5 extensions (Q_nl, b1, b2, b3, Qmax), each of which is an image with dimensions 2,040 x 2,040.
-These extensions are described in Section 3.2.1 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+These extensions are described in Section 3.2.1 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 
 
 *Filename Format:*

--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -22,42 +22,53 @@ The main Quick Release data product is the Level 2 Spectral Image MEF.
 There are 6 Spectral MEFs (one for each detector) for each sky pointing.
 Each Spectral MEF is approximately 70 MB and contains 6 extensions:
 
-1. **IMAGE** - Calibrated surface brightness flux density in units of MJy/sr, stored as a 2040 x 2040 image.
-No zodiacal light subtraction is applied.
+IMAGE
+ : Calibrated surface brightness flux density in units of MJy/sr, stored as a 2040 x 2040 image.
+   No zodiacal light subtraction is applied.
 
-The SPHEREx focal plane is split with a dichroic to three short-wavelength and three long-wavelength detector arrays.
-Two focal plane assemblies (FPAs) simultaneously image the sky through a dichroic beam splitter.
-Each FPA contains three 2K x 2K detector arrays placed behind a set of linear variable filters (LVFs), providing narrow-band response with a band center that varies along one axis of the array.
-SPHEREx obtains spectra through multiple exposures, placing a given source at multiple positions in the field of view, where it is measured at multiple wavelengths by repointing the spacecraft.
+   The SPHEREx focal plane is split with a dichroic to three short-wavelength and three long-wavelength detector arrays.
+   Two focal plane assemblies (FPAs) simultaneously image the sky through a dichroic beam splitter.
+   Each FPA contains three 2K x 2K detector arrays placed behind a set of linear variable filters (LVFs), providing narrow-band response with a band center that varies along one axis of the array.
+   SPHEREx obtains spectra through multiple exposures, placing a given source at multiple positions in the field of view, where it is measured at multiple wavelengths by repointing the spacecraft.
 
-* Band 1: λ= 0.75 - 1.09 µm; R=39
-* Band 2: λ= 1.10 - 1.62 µm; R=41
-* Band 3: λ= 1.63 - 2.41 µm; R=41
-* Band 4: λ= 2.42 - 3.82 µm; R=35
-* Band 5: λ= 3.83 - 4.41 µm; R=112
-* Band 6: λ= 4.42 - 5.00 µm; R=128
+   * Band 1: λ= 0.75 - 1.09 µm; R=39
+   * Band 2: λ= 1.10 - 1.62 µm; R=41
+   * Band 3: λ= 1.63 - 2.41 µm; R=41
+   * Band 4: λ= 2.42 - 3.82 µm; R=35
+   * Band 5: λ= 3.83 - 4.41 µm; R=112
+   * Band 6: λ= 4.42 - 5.00 µm; R=128
 
-2. **FLAG** - Bitmap of per-pixel status and processing flags, stored as a 2040 x 2040 image.
-The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+FLAG
+ : Bitmap of per-pixel status and processing flags, stored as a 2040 x 2040 image.
+   The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
 
-3. **VARIANCE** - Variance of calibrated surface brightness flux in units of (MJy/sr)^2, stored as a 2,040 x 2,040 image.
+VARIANCE
+ : Variance of calibrated surface brightness flux in units of (MJy/sr)^2, stored as a 2,040 x 2,040 image.
 
-4. **ZODI** - Modeled zodiacal light background flux in units of MJy/sr, stored as a 2040 x 2040 image.
-This has not been subtracted from the IMAGE extension.
+ZODI
+ : Modeled zodiacal light background flux in units of MJy/sr, stored as a 2040 x 2040 image.
+   This has not been subtracted from the IMAGE extension.
 
-5. **PSF** - 121 Point-spread functions (PSFs); each PSF is represented as a 101 x 101 image and all 121 are assembled together into a cube.
+PSF
+ : 121 Point-spread functions (PSFs); each PSF is represented as a 101 x 101 image and all 121 are assembled together into a cube.
 
-6. **WCS-WAVE** - Spectral World Coordinate System (WCS) FITS-compliant lookup table that maps spectral image pixel coordinates to central wavelengths and bandwidths.
-The lookup table consists of 1 row with 3 columns (X, Y, VALUES).
-X and Y are each arrays defining a grid of control points in spectral image pixel space.
-VALUES is an array of two-element arrays: at each (X, Y) control point, the two-element array contains the central wavelength and the corresponding bandwidth.
-Originally adopted to support the unique nature of the SPHEREx LVF filters, this rarely-used part of the FITS standard has yet to be implemented by all readers.
-If your FITS client software doesn't automatically recognize this, you can manually determine the central wavelength or bandwidth at an arbitrary pixel location by identifying the four nearest control points and applying bilinear interpolation.
-This method yields values accurate to within approximately 1 nm.
- The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below ("Additional Product: Spectral WCS").
-The fidelity of the WCS-WAVE lookup table is intended for visualization purposes.
-For science analysis, use the CWAVE and CBAND extensions in the Spectral WCS calibration product.
+WCS-WAVE
+ : Spectral World Coordinate System (WCS) FITS-compliant lookup table that maps spectral image pixel coordinates to central wavelengths and bandwidths.
+   The lookup table consists of 1 row with 3 columns (X, Y, VALUES).
 
+   X and Y are each arrays defining a grid of control points in spectral image pixel space.
+
+   VALUES is an array of two-element arrays: at each (X, Y) control point, the two-element array contains the central wavelength and the corresponding bandwidth.
+
+   :::{note}
+   This was originally adopted to support the unique nature of the SPHEREx LVF filters, this rarely-used part of the FITS standard has yet to be implemented by all readers.
+
+   If your FITS client software doesn't automatically recognize this, you can manually determine the central wavelength or bandwidth at an arbitrary pixel location by identifying the four nearest control points and applying bilinear interpolation.
+   This method yields values accurate to within approximately 1 nm.
+   The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below ("Additional Product: Spectral WCS").
+   The fidelity of the WCS-WAVE lookup table is intended for visualization purposes.
+   For science analysis, use the CWAVE and CBAND extensions in the Spectral WCS calibration product.
+   :::
 
 *Filename Format:*
 

--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -1,25 +1,34 @@
 # SPHEREx Data Products Available at IRSA
 
-A detailed description of SPHEREx data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf). Here we provide a concise summary of the science, calibration, and additional data products available at IRSA. This summary includes filenaming conventions, for which we adopt the following definitions:
+A detailed description of SPHEREx data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+Here we provide a concise summary of the science, calibration, and additional data products available at IRSA.
+This summary includes filenaming conventions, for which we adopt the following definitions:
 
-- `Planning Period` designates the survey plan uploaded to the spacecraft, e.g. `2025W18_2B`. Each planning period covers approximately 3.5 days of operation.
+- `Planning Period` designates the survey plan uploaded to the spacecraft, e.g. `2025W18_2B`.
+Each planning period covers approximately 3.5 days of operation.
 
-- `Observation ID` includes the survey planning period and the large and small slew counters, e.g. `2025W18_2B_0001_1`
+- `Observation ID` includes the survey planning period and the large and small slew counters, e.g. `2025W18_2B_0001_1`.
 
-- `Detector` is an integer from 1 through 6
+- `Detector` is an integer from 1 through 6.
 
-- `Version` is the version of this file, e.g. 'l2' for "level 2" data products
+- `Version` is the version of this file, e.g. 'l2' for "level 2" data products.
 
-- `Processing Date` includes the year and the number of days into the year, e.g. `2025-164`
+- `Processing Date` includes the year and the number of days into the year, e.g. `2025-164`.
 
 
 ## Main Science Data Product: Spectral Image Multi-Extension FITS Files (MEF)
 
-The main Quick Release data product is the Level 2 Spectral Image MEF. There are 6 Spectral MEFs (one for each detector) for each sky pointing. Each Spectral MEF is approximately 70 MB and contains 6 extensions:
+The main Quick Release data product is the Level 2 Spectral Image MEF.
+There are 6 Spectral MEFs (one for each detector) for each sky pointing.
+Each Spectral MEF is approximately 70 MB and contains 6 extensions:
 
-1. **IMAGE** - Calibrated surface brightness flux density in units of MJy/sr, stored as a 2040 x 2040 image. No zodiacal light subtraction is applied.
+1. **IMAGE** - Calibrated surface brightness flux density in units of MJy/sr, stored as a 2040 x 2040 image.
+No zodiacal light subtraction is applied.
 
-The SPHEREx focal plane is split with a dichroic to three short-wavelength and three long-wavelength detector arrays. Two focal plane assemblies (FPAs) simultaneously image the sky through a dichroic beam splitter. Each FPA contains three 2K x 2K detector arrays placed behind a set of linear variable filters (LVFs), providing narrow-band response with a band center that varies along one axis of the array. SPHEREx obtains spectra through multiple exposures, placing a given source at multiple positions in the field of view, where it is measured at multiple wavelengths by repointing the spacecraft.
+The SPHEREx focal plane is split with a dichroic to three short-wavelength and three long-wavelength detector arrays.
+Two focal plane assemblies (FPAs) simultaneously image the sky through a dichroic beam splitter.
+Each FPA contains three 2K x 2K detector arrays placed behind a set of linear variable filters (LVFs), providing narrow-band response with a band center that varies along one axis of the array.
+SPHEREx obtains spectra through multiple exposures, placing a given source at multiple positions in the field of view, where it is measured at multiple wavelengths by repointing the spacecraft.
 
 * Band 1: λ= 0.75 - 1.09 µm; R=39
 * Band 2: λ= 1.10 - 1.62 µm; R=41
@@ -28,20 +37,26 @@ The SPHEREx focal plane is split with a dichroic to three short-wavelength and t
 * Band 5: λ= 3.83 - 4.41 µm; R=112
 * Band 6: λ= 4.42 - 5.00 µm; R=128
 
-2. **FLAG** - Bitmap of per-pixel status and processing flags, stored as a 2040 x 2040 image. The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+2. **FLAG** - Bitmap of per-pixel status and processing flags, stored as a 2040 x 2040 image.
+The definition of the flags are provided in Table 8 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
 
 3. **VARIANCE** - Variance of calibrated surface brightness flux in units of (MJy/sr)^2, stored as a 2,040 x 2,040 image.
 
-4. **ZODI** - Modeled zodiacal light background flux in units of MJy/sr, stored as a 2040 x 2040 image. This has not been subtracted from the IMAGE extension.
-
+4. **ZODI** - Modeled zodiacal light background flux in units of MJy/sr, stored as a 2040 x 2040 image.
+This has not been subtracted from the IMAGE extension.
 
 5. **PSF** - 121 Point-spread functions (PSFs); each PSF is represented as a 101 x 101 image and all 121 are assembled together into a cube.
 
-6. **WCS-WAVE** - Spectral World Coordinate System (WCS) FITS-compliant lookup table that maps spectral image pixel coordinates to central wavelengths and bandwidths. The lookup table consists of 1 row with 3 columns (X, Y, VALUES). X and Y are each arrays defining a grid of control points in spectral image pixel space. VALUES is an array of two-element arrays: at each (X, Y) control point, the two-element array contains the central wavelength and the corresponding bandwidth. Originally adopted to support the unique nature of the SPHEREx LVF filters, this rarely-used part of the FITS standard has yet to be implemented by all readers. If your FITS client software doesn't automatically recognize this, you can manually determine the central wavelength or bandwidth at an arbitrary pixel location by identifying the four nearest control points and applying bilinear interpolation. This method yields values accurate to within approximately 1 nm.  The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below ("Additional Product: Spectral WCS").
+6. **WCS-WAVE** - Spectral World Coordinate System (WCS) FITS-compliant lookup table that maps spectral image pixel coordinates to central wavelengths and bandwidths.
+The lookup table consists of 1 row with 3 columns (X, Y, VALUES).
+X and Y are each arrays defining a grid of control points in spectral image pixel space.
+VALUES is an array of two-element arrays: at each (X, Y) control point, the two-element array contains the central wavelength and the corresponding bandwidth.
+Originally adopted to support the unique nature of the SPHEREx LVF filters, this rarely-used part of the FITS standard has yet to be implemented by all readers.
+If your FITS client software doesn't automatically recognize this, you can manually determine the central wavelength or bandwidth at an arbitrary pixel location by identifying the four nearest control points and applying bilinear interpolation.
+This method yields values accurate to within approximately 1 nm.
+ The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below ("Additional Product: Spectral WCS").
 The fidelity of the WCS-WAVE lookup table is intended for visualization purposes.
 For science analysis, use the CWAVE and CBAND extensions in the Spectral WCS calibration product.
-
-
 
 
 *Filename Format:*
@@ -57,6 +72,7 @@ For science analysis, use the CWAVE and CBAND extensions in the Spectral WCS cal
 
 The Absolute Gain Matrix products are ~16 MB FITS image files (one per detector) with dimensions 2,040 × 2,040 and units of (MJy/sr) / (e−/s).
 
+
 *Filename Format:*
 
 - `abs_gain_matrix_D[Detector]_spx_cal-agm-v[Version]-[Processing Date].fits`
@@ -65,9 +81,14 @@ The Absolute Gain Matrix products are ~16 MB FITS image files (one per detector)
 
 - `abs_gain_matrix_D1_spx_cal-agm-v4-2025-161.fits`
 
+
 ## Calibration Product: Exposure-Averaged Point Spread Functions (PSFs)
 
-The Exposure-Averaged Point Spread Functions (PSFs) are ~6 MB FITS cubes (one for each detector) with dimensions 101 × 101 × 121. Each of the 121 layers represents a "super-resolution" PSF estimate in a different region (defined by an 11x11 grid) of the detector. Each PSF is a two-dimensional array with size of 101 × 101 pixels. The PSFs are oversampled such that 10 PSF pixels cover the same spatial extent as one spectral image pixel (0.615 arcsec).
+The Exposure-Averaged Point Spread Functions (PSFs) are ~6 MB FITS cubes (one for each detector) with dimensions 101 × 101 × 121.
+Each of the 121 layers represents a "super-resolution" PSF estimate in a different region (defined by an 11x11 grid) of the detector.
+Each PSF is a two-dimensional array with size of 101 × 101 pixels.
+The PSFs are oversampled such that 10 PSF pixels cover the same spatial extent as one spectral image pixel (0.615 arcsec).
+
 
 *Filename Format:*
 
@@ -77,9 +98,11 @@ The Exposure-Averaged Point Spread Functions (PSFs) are ~6 MB FITS cubes (one fo
 
 - `average_psf_D1_spx_cal-psf-v4-2025-161.fits`
 
+
 ## Calibration Product: Dark Current
 
 The Dark Current products are ~16 MB FITS image files (one per detector) with dimensions 2,040 x 2,040 and units of electron/s.
+
 
 *Filename Format:*
 
@@ -89,9 +112,14 @@ The Dark Current products are ~16 MB FITS image files (one per detector) with di
 
 - `dark_D1_spx_cal-drk-v4-2025-161.fits`
 
+
 ## Calibration Product: Dichroic
 
-The Dichroic products are ~16 MB FITS image files with dimensions 2,040 x 2,040. The pixel value is 0 for pixels that are unaffected by flux attenuation due to the dicroic filter and 1 for impacted pixels. A pixel is considered impacted if the flux attenuation is 50% or higher. Note that only bands 3 and 4 have any non-zero values.
+The Dichroic products are ~16 MB FITS image files with dimensions 2,040 x 2,040.
+The pixel value is 0 for pixels that are unaffected by flux attenuation due to the dicroic filter and 1 for impacted pixels.
+A pixel is considered impacted if the flux attenuation is 50% or higher.
+Note that only bands 3 and 4 have any non-zero values.
+
 
 *Filename Format:*
 
@@ -101,9 +129,11 @@ The Dichroic products are ~16 MB FITS image files with dimensions 2,040 x 2,040.
 
 - `dichroic_D1_spx_base-2025-158.fits`
 
+
 ## Calibration Product: Electronic Gain Factors
 
 The Electronic Gain Factor product is a single YAML file that includes the provenance information for the detectors and a list of 32 gain values per detector.
+
 
 *Filename Format:*
 
@@ -113,9 +143,12 @@ The Electronic Gain Factor product is a single YAML file that includes the prove
 
 - `gain_factors_spx_base-2025-158.yaml`
 
+
 ## Additional Product: Nonfunctional Pixels
 
-The Nonfunctional Pixel products are ~32 MB FITS image files (one per detector) with dimensions 2,040 x 2,040. Pixel values are 1 for pixels known to be permanently non-functioning and 0 otherwise.
+The Nonfunctional Pixel products are ~32 MB FITS image files (one per detector) with dimensions 2,040 x 2,040.
+Pixel values are 1 for pixels known to be permanently non-functioning and 0 otherwise.
+
 
 *Filename Format:*
 
@@ -125,9 +158,13 @@ The Nonfunctional Pixel products are ~32 MB FITS image files (one per detector) 
 
 - `nonfunc_D1_spx_base-2025-158.fits`
 
+
 ## Additional Product: Nonlinearity Parameters
 
-The Nonlinearity Parameter products are ~79 MB multi-extension FITS files (one per detector). Each file contains 5 extensions (Q_nl, b1, b2, b3, Qmax), each of which is an image with dimensions 2,040 x 2,040. These extensions are described in Section 3.2.1 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+The Nonlinearity Parameter products are ~79 MB multi-extension FITS files (one per detector).
+Each file contains 5 extensions (Q_nl, b1, b2, b3, Qmax), each of which is an image with dimensions 2,040 x 2,040.
+These extensions are described in Section 3.2.1 of the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR_v1.0.pdf).
+
 
 *Filename Format:*
 
@@ -137,9 +174,13 @@ The Nonlinearity Parameter products are ~79 MB multi-extension FITS files (one p
 
 - `nonlinear_pars_D1_spx_base-2025-158.fits`
 
+
 ## Additional Product: Read Noise Parameters
 
-The Read Noise Parameters products are ~48 MB multi-extension FITS files (one per detector). Each file has 2 extensions: READNOISE-1 and READNOISE-2. Each extension is an image with dimensions 2040 × 2040 and units of electrons.
+The Read Noise Parameters products are ~48 MB multi-extension FITS files (one per detector).
+Each file has 2 extensions: READNOISE-1 and READNOISE-2.
+Each extension is an image with dimensions 2040 × 2040 and units of electrons.
+
 
 *Filename Format:*
 
@@ -149,20 +190,24 @@ The Read Noise Parameters products are ~48 MB multi-extension FITS files (one pe
 
 - `readnoise_pars_D1_spx_base-2025-158.fits`
 
+
 ## Additional Product: Spectral WCS
 
 The Spectral WCS products are ~32 MB multi-extension FITS files (one per detector).
 Each file has 3 extensions: CWAVE, CBAND, and WCS-WAVE.
 For science analysis, use the values in the CWAVE and CBAND layers, not the WCS-WAVE which is intended for visualization.
 
-CWAVE is an image with dimensions 2,040 x 2,040. It contains the central wavelength in microns for each pixel.
+CWAVE is an image with dimensions 2,040 x 2,040.
+It contains the central wavelength in microns for each pixel.
 
-CBAND is an image with dimensions 2,040 x 2,040. It contains the bandwidth in microns for each pixel.
+CBAND is an image with dimensions 2,040 x 2,040.
+It contains the bandwidth in microns for each pixel.
 
-WCS-WAVE is a table with 3 columns (X, Y, VALUES) and 1 row. This is equivalent to the WCS-WAVE extension in the Spectral Image MEF file described above.
+WCS-WAVE is a table with 3 columns (X, Y, VALUES) and 1 row.
+This is equivalent to the WCS-WAVE extension in the Spectral Image MEF file described above.
+
 
 *Filename Format:*
-
 - `spectral_wcs_D[Detector]_spx_base-[Processing Date].fits`
 
 *Example:*

--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -65,7 +65,7 @@ WCS-WAVE
 
    If your FITS client software doesn't automatically recognize this, you can manually determine the central wavelength or bandwidth at an arbitrary pixel location by identifying the four nearest control points and applying bilinear interpolation.
    This method yields values accurate to within approximately 1 nm.
-   The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below ("Additional Product: Spectral WCS").
+   The information in the WCS-WAVE extension of the Spectral Image MEF is also provided in a stand-alone data product described below in [](#data-products-spectral-wcs).
    The fidelity of the WCS-WAVE lookup table is intended for visualization purposes.
    For science analysis, use the CWAVE and CBAND extensions in the Spectral WCS calibration product.
    :::
@@ -201,7 +201,7 @@ Each extension is an image with dimensions 2040 × 2040 and units of electrons.
 
 - `readnoise_pars_D1_spx_base-2025-158.fits`
 
-
+(data-products-spectral-wcs)=
 ## Additional Product: Spectral WCS
 
 The Spectral WCS products are ~32 MB multi-extension FITS files (one per detector).


### PR DESCRIPTION
While doing https://github.com/Caltech-IPAC/spherex-archive-documentation/pull/10 I have noticed a couple of other things that could be improved. I added most of the new things incrementally so we can leave commits out easily.

I have also changed the links to point to the always up-to-date https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf rather than to a numbered version.


Hope you like the new look.

(This PR also started with the internal refactoring to follow most of the style markdown styleguide we started to adopt for out other repos)