### PR TITLE
date and dp heading

### DIFF
--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -1,4 +1,4 @@
- SPHEREx Data Products Available at IRSA
+# SPHEREx Data Products
 
 A detailed description of SPHEREx data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 Here we provide a concise summary of the science, calibration, and additional data products available at IRSA.

--- a/myst.yml
+++ b/myst.yml
@@ -3,7 +3,7 @@ version: 1
 project:
   title: SPHEREx Archive at IRSA
   subject: SPHEREx Archive at IRSA
-  date: 2025-09-12
+  date: 2025-09-25
   # description:
   # keywords: []
   authors: [Caltech/IPAC-IRSA]


### PR DESCRIPTION
Changed the date and the heading of the data products section because a "#" was dropped.