### PR TITLE
Remove references to QR1

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -10,8 +10,7 @@ This User Guide will evolve as the SPHEREx project delivers new data products an
 
 SPHEREx is a NASA Astrophysics Medium Explorer mission that launched in March 2025.
 During its planned two-year mission, SPHEREx will obtain 0.75-5 micron spectroscopy over the entire sky, with deeper data in the SPHEREx Deep Fields.
-IRSA began releasing SPHEREx Quick Release 2 (QR2) data on a weekly basis in October 2025.
-QR2 features substantially improved calibrations and supersedes QR1.
+IRSA began releasing SPHEREx Spectral Image data on a weekly basis in July 2025.
 SPHEREx data will be used to:
 
 * **constrain the physics of inflation** by measuring its imprints on the three-dimensional large-scale distribution of matter,

--- a/documentation/spherex_data_access.md
+++ b/documentation/spherex_data_access.md
@@ -22,14 +22,8 @@ SPHEREx data products are laid out in directories that can be navigated with sta
 This is convenient for users to get a quick sense of the types of data products that are available, to quickly download some examples by clicking through the directory tree, and to script bulk downloads using `wget` or `curl`.
 
 The root of the SPHEREx QR2 on-premises data directories is: [https://irsa.ipac.caltech.edu/ibe/data/spherex/qr2](https://irsa.ipac.caltech.edu/ibe/data/spherex/qr2).
-For QR1, replace '/qr2' with '/qr'.
 All of the data products are also available on the cloud via AWS.
 Please see our [instructions for accessing on-cloud SPHEREx data](https://irsa.ipac.caltech.edu/cloud_access/#spherex).
-
-:::{note}
-QR1 is superseded by QR2.
-The QR1 files will be available through January 2026 for reference.
-:::
 
 The public data products are organized into subdirectories based on the following organizational scheme:
 
@@ -43,7 +37,7 @@ The public data products are organized into subdirectories based on the followin
 * **Nonlinearity Parameters:** `nonlinear_pars/base-[Processing Date]/[Detector]/`
 * **Read Noise Parameters:** `readnoise_pars/base-[Processing Date]/[Detector]/`
 * **Solid Angle Pixel Map:** `solid_angle_pixel_map/cal-sapm-v[Version]-[Processing Date]/[Detector]/`
-* **Spectral WCS:** `spectral_wcs/cal-wcs-v[Version]-[Processing Date]/[Detector]/` (QR2) or `spectral_wcs/base-[Processing Date]/[Detector]/` (QR1)
+* **Spectral WCS:** `spectral_wcs/cal-wcs-v[Version]-[Processing Date]/[Detector]/`
 
 The content of each subdirectory and the filename formats are described in greater detail in the {ref}`Data Products <data-products>` section of this user guide and in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 

--- a/documentation/spherex_data_products.md
+++ b/documentation/spherex_data_products.md
@@ -3,11 +3,8 @@
 
 IRSA began releasing SPHEREx Spectral Image data on a weekly basis in July 2025 (Quick Release 1; QR1).
 In October 2025, IRSA began distributing SPHEREx Spectral Image data processed with substantially improved calibrations.
-This new processing, referred to as QR2, includes reprocessed versions of all Spectral Image data acquired since the start of the mission.
+This new processing, referred to as QR2, supersedes QR1 and includes reprocessed versions of all Spectral Image data acquired since the start of the mission.
 Future quick releases will also use the QR2 pipeline.
-IRSA will continue to provide access to QR1 data through January 2026 for reference.
-However, QR2 supersedes QR1 and will be the default returned in the SPHEREx Data Explorer and by all IRSA program-friendly APIs.
-QR1 data will remain available only through browsable directory listings.
 
 A detailed description of SPHEREx quick release data products available to the public is provided in the [SPHEREx Explanatory Supplement](https://irsa.ipac.caltech.edu/data/SPHEREx/docs/SPHEREx_Expsupp_QR.pdf).
 Here we provide a concise summary of the science, calibration, and additional data products available at IRSA.
@@ -254,10 +251,8 @@ This is equivalent to the WCS-WAVE extension in the Spectral Image MEF file desc
 
 *Filename Format:*
 
-- QR2: `spectral_wcs_D[Detector]_spx_cal-wcs-v[Version]-[Processing Date].fits`
-- QR1: `spectral_wcs_D[Detector]_spx_base-[Processing Date].fits`
+- `spectral_wcs_D[Detector]_spx_cal-wcs-v[Version]-[Processing Date].fits`
 
 *Example:*
 
-- QR2: `spectral_wcs_D1_spx_cal-wcs-v4-2025-254.fits`
-- QR1: `spectral_wcs_D1_spx_base-2025-158.fits`
+- `spectral_wcs_D1_spx_cal-wcs-v4-2025-254.fits`

--- a/myst.yml
+++ b/myst.yml
@@ -3,7 +3,7 @@ version: 1
 project:
   title: SPHEREx Archive at IRSA
   subject: SPHEREx Archive at IRSA
-  date: 2025-10-31
+  date: 2026-02-18
   # description:
   # keywords: []
   authors: [Caltech/IPAC-IRSA]


### PR DESCRIPTION
Closes #18 

Removes all references to QR1 except for an explanation on the data products page.